### PR TITLE
fix README command syntax for GPU docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 docker compose up
-docker compose up -f docker-compose.gpu.yml up  # for GPU
+docker compose -f docker-compose.gpu.yml up  # for GPU
 ```
 
 ## Request


### PR DESCRIPTION
Small fix to README.md to remove the extra 'up' in the docker-compose.gpu.ylml command